### PR TITLE
More trivial changes from high -Wlevels

### DIFF
--- a/m68k.h
+++ b/m68k.h
@@ -293,6 +293,9 @@ void m68k_set_fc_callback(void  (*callback)(unsigned int new_fc));
  */
 void m68k_set_instr_hook_callback(void  (*callback)(unsigned int pc));
 
+/* XXX: Two undocumented callback facilities */
+void m68k_set_cmpild_instr_callback(void  (*callback)(unsigned int, int));
+void m68k_set_rte_instr_callback(void  (*callback)(void));
 
 
 /* ======================================================================== */

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -55,13 +55,13 @@ extern void m68ki_build_opcode_table(void);
 /* ================================= DATA ================================= */
 /* ======================================================================== */
 
-int  m68ki_initial_cycles;
+static int  m68ki_initial_cycles;
 int  m68ki_remaining_cycles = 0;                     /* Number of clocks remaining */
 uint m68ki_tracing = 0;
 uint m68ki_address_space;
 
 #ifdef M68K_LOG_ENABLE
-const char *const m68ki_cpu_names[] =
+static const char *const m68ki_cpu_names[] =
 {
 	"Invalid CPU",
 	"M68000",

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "m68k.h"
+#include "m68kcpu.h"
 
 #ifndef uint32
 #define uint32 uint
@@ -2086,8 +2087,8 @@ static void d68000_move_to_usp(void)
 static void d68010_movec(void)
 {
 	uint extension;
-	char* reg_name;
-	char* processor;
+	const char* reg_name;
+	const char* processor;
 	LIMIT_CPU_TYPES(M68010_PLUS);
 	extension = read_imm_16();
 

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -596,7 +596,7 @@ static uint64 READ_EA_64(int ea)
 
 static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 {
-	floatx80 fpr;
+	floatx80 fpr = {0, 0};
 
 	switch (mode)
 	{
@@ -659,7 +659,7 @@ static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 
 static floatx80 READ_EA_PACK(int ea)
 {
-	floatx80 fpr;
+	floatx80 fpr = {0, 0};
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
 
@@ -1052,7 +1052,7 @@ static void fpgen_rm_reg(uint16 w2)
 	int src = (w2 >> 10) & 0x7;
 	int dst = (w2 >>  7) & 0x7;
 	int opmode = w2 & 0x7f;
-	floatx80 source;
+	floatx80 source = {0, 0};
 
 	// fmovecr #$f, fp0	f200 5c0f
 


### PR DESCRIPTION
More changes resulting from compiling with high -W levels.

I'm not entirely sure if the two `m68k_set_*_callback()` are supposed to be undocumented or not.